### PR TITLE
Make the sample rate of the wav be that of the AudioContext

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -38,7 +38,7 @@
     this.exportWAV = function(){
       var buffer = mergeBuffers(recBuffers, recLength);
       var waveData = PCMData.encode({
-        sampleRate: 44100,
+        sampleRate: this.context.sampleRate,
         channelCount:   2,
         bytesPerSample: 2,    //16bit
         data:       buffer


### PR DESCRIPTION
As noted in the W3C Audio WG mailing list, the audio gets saved at a different rate than it's played back at. This patch fixes that issue.
