### PR TITLE
Get rid of the PCMData.js dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 
 ## A plugin for recording/exporting the output of Web Audio API nodes
 
-### Dependencies
-
-This plugin requires Jussi Kalliokoski's terrific PCMData.js library, which you can find in original or minified form [here](https://github.com/jussi-kalliokoski/pcmdata.js/tree/master/lib).
-
 ### Syntax
 #### Constructor
     var rec = new Recorder(source [, config])

--- a/recorderWorker.js
+++ b/recorderWorker.js
@@ -1,5 +1,3 @@
-importScripts('pcmdata.min.js');
-
 var recLength = 0,
   recBuffers = [],
   sampleRate;
@@ -35,17 +33,9 @@ function record(inputBuffer){
 
 function exportWAV(type){
   var buffer = mergeBuffers(recBuffers, recLength);
-  var waveData = PCMData.encode({
-    sampleRate:     sampleRate,
-    channelCount:   2,
-    bytesPerSample: 2,    //16bit
-    data:           buffer
-  });
-  var byteArray = new Uint8Array(waveData.length);
-  for (var i = 0; i < waveData.length; i++){
-    byteArray[i] = waveData.charCodeAt(i);
-  }
-  var audioBlob = new Blob([byteArray], { type: type });
+  var dataview = encodeWAV(buffer);
+  var audioBlob = new Blob([dataview], { type: type });
+
   this.postMessage(audioBlob);
 }
 
@@ -77,4 +67,53 @@ function interleave(inputL, inputR){
     inputIndex++;
   }
   return result;
+}
+
+function floatTo16BitPCM(output, offset, input){
+  for (var i = 0; i < input.length; i++, offset+=2){
+    var s = Math.max(-1, Math.min(1, input[i]));
+    output.setInt16(offset, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+  }
+}
+
+function writeString(view, offset, string){
+  for (var i = 0; i < string.length; i++){
+    view.setUint8(offset + i, string.charCodeAt(i));
+  }
+}
+
+function encodeWAV(samples){
+  var buffer = new ArrayBuffer(44 + samples.length * 2);
+  var view = new DataView(buffer);
+
+  /* RIFF identifier */
+  writeString(view, 0, 'RIFF');
+  /* file length */
+  view.setUint32(4, 32 + samples.length * 2, true);
+  /* RIFF type */
+  writeString(view, 8, 'WAVE');
+  /* format chunk identifier */
+  writeString(view, 12, 'fmt ');
+  /* format chunk length */
+  view.setUint32(16, 16, true);
+  /* sample format (raw) */
+  view.setUint16(20, 1, true);
+  /* channel count */
+  view.setUint16(22, 2, true);
+  /* sample rate */
+  view.setUint32(24, sampleRate, true);
+  /* byte rate (sample rate * block align) */
+  view.setUint32(28, sampleRate * 4, true);
+  /* block align (channel count * bytes per sample) */
+  view.setUint16(32, 4, true);
+  /* bits per sample */
+  view.setUint16(34, 16, true);
+  /* data chunk identifier */
+  writeString(view, 36, 'data');
+  /* data chunk length */
+  view.setUint32(40, samples.length * 2, true);
+
+  floatTo16BitPCM(view, 44, samples);
+
+  return view;
 }


### PR DESCRIPTION
Hey Matt,

I've been trying to downplay PCMData.js because it's a remnant of a time when there were no good ways of handling binary data in JS. I'm keeping the repo up just for backwards compatibility.

Therefore, I implemented a simple WAV decoder into this project, using ArrayBuffers, which saves us the roundtrip of converting stuff into a string and then back into a buffer.

All in all, this should be much faster (I didn't benchmark, but my world is broken if string manipulating binary data is faster) and gets rid of the dependency on an abandoned project. :)

Cheers,
Jussi
