### PR TITLE
Add a getBuffer method to get the merged recording buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ This will generate a Blob object containing the recording in WAV format. The cal
 
 In addition, you may specify the type of Blob to be returned (defaults to 'audio/wav').
 
+    rec.getBuffer([callback])
+
+This will pass the recorded buffer (as a Float32Array) to the callback. It can be played back by creating a new source buffer and setting this as its channel data (i.e. `newSource.buffer.getChannelData(0).set(recordedBuffer)`).
+
     rec.configure(config)
 
 This will set the configuration for Recorder by passing in a config object.

--- a/recorder.js
+++ b/recorder.js
@@ -48,6 +48,11 @@
       worker.postMessage({ command: 'clear' });
     }
 
+    this.getBuffer = function(cb) {
+      currCallback = cb || config.callback;
+      worker.postMessage({ command: 'getBuffer' })
+    }
+
     this.exportWAV = function(cb, type){
       currCallback = cb || config.callback;
       type = type || config.type || 'audio/wav';

--- a/recorderWorker.js
+++ b/recorderWorker.js
@@ -13,6 +13,9 @@ this.onmessage = function(e){
     case 'exportWAV':
       exportWAV(e.data.type);
       break;
+    case 'getBuffer':
+      getBuffer();
+      break;
     case 'clear':
       clear();
       break;
@@ -37,6 +40,11 @@ function exportWAV(type){
   var audioBlob = new Blob([dataview], { type: type });
 
   this.postMessage(audioBlob);
+}
+
+function getBuffer() {
+  var buffer = mergeBuffers(recBuffers, recLength)
+  this.postMessage(buffer);
 }
 
 function clear(){


### PR DESCRIPTION
I wanted to be able to use the recorded buffer as an audio source so I could play back the recorded audio using the Web Audio API, but there was no method to retrieve the merged buffer from the worker, so I added one. Also added documentation for it in the README.
