### PR TITLE
Use the `CustomEvent` constructor instead of `document.createEvent`.

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -77,8 +77,7 @@
     var link = window.document.createElement('a');
     link.href = url;
     link.download = filename || 'output.wav';
-    var click = document.createEvent("Event");
-    click.initEvent("click", true, true);
+    var click = new CustomEvent('click', {bubbles: true, cancelable: true});
     link.dispatchEvent(click);
   }
 


### PR DESCRIPTION
According to [this page on the MDN](https://developer.mozilla.org/en-US/docs/Web/API/document.createEvent) `document.createEvent` is deprecated and [event constructors](https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent) should be used instead.
