### PR TITLE
README edit: removing node from createBufferSource() method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ In addition, you may specify the type of Blob to be returned (defaults to 'audio
 This will pass the recorded stereo buffer (as an array of two Float32Arrays, for the separate left and right channels) to the callback. It can be played back by creating a new source buffer and setting these buffers as the separate channel data:
 
 	function getBufferCallback( buffers ) {
-		var newSource = audioContext.createBufferSourceNode();
+		var newSource = audioContext.createBufferSource();
 		var newBuffer = audioContext.createBuffer( 2, buffers[0].length, audioContext.sampleRate );
 		newBuffer.getChannelData(0).set(buffers[0]);
 		newBuffer.getChannelData(1).set(buffers[1]);


### PR DESCRIPTION
updated documentation to reflect correct method name. 
