### PR TITLE
Fix RIFF chunk length

### DIFF
--- a/recorderWorker.js
+++ b/recorderWorker.js
@@ -100,8 +100,8 @@ function encodeWAV(samples){
 
   /* RIFF identifier */
   writeString(view, 0, 'RIFF');
-  /* file length */
-  view.setUint32(4, 32 + samples.length * 2, true);
+  /* RIFF chunk length */
+  view.setUint32(4, 36 + samples.length * 2, true);
   /* RIFF type */
   writeString(view, 8, 'WAVE');
   /* format chunk identifier */


### PR DESCRIPTION
Note 4 bytes of RIFF Format is a part of RIFF chunk length since is not padding of RIFF container
Try generate a WAV file from Audacity / Check Microsoft & IBM's RIFF Specification
