### PR TITLE
MouseEvent interface instead of initEvent

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -79,9 +79,10 @@
     var link = window.document.createElement('a');
     link.href = url;
     link.download = filename || 'output.wav';
-    var click = document.createEvent("Event");
-    click.initEvent("click", true, true);
-    link.dispatchEvent(click);
+    var event = new MouseEvent('click', {'view': window,
+                                         'bubbles': true,
+                                         'cancelable': true});
+     link.dispatchEvent(event);    
   }
 
   window.Recorder = Recorder;


### PR DESCRIPTION
[The initEvent method is deprecated.](https://developer.mozilla.org/en-US/docs/Web/API/Event.initEvent)
