### PR TITLE
Use a two channel script processor even for mono recordings

### DIFF
--- a/recorder.js
+++ b/recorder.js
@@ -9,7 +9,7 @@
     this.context = source.context;
     this.node = (this.context.createScriptProcessor ||
                  this.context.createJavaScriptNode).call(this.context,
-                 bufferLen, numChannels, numChannels);
+                 bufferLen, 2, numChannels);
     var worker = new Worker(config.workerPath || WORKER_PATH);
     worker.postMessage({
       command: 'init',


### PR DESCRIPTION
This is a difficult thing to explain, but basically if you have an interface containing multiple input channels and you record in stereo on only one of the channels, the script processor node will mix down the channels to mono, and the resulting signal level will be cut in half.

In order to reproduce you have to

- Use a recording interface with separate input channels for left and right
- Call `navigator.getUserMedia` with `echoCancellation: false` constraint
- Plug a microphone or instrument into only the left channel of your interface

I thought this was a browser bug and put together a demo here
https://craig.is/demoing/web-audio-script-processor-bug

It turns out this is the expected behavior though.  When your input is stereo with sound only coming into one channel and you pass to a mono `ScriptProcessorNode`, it sums the left and right channels to a single mono channel and the resulting recording ends up half the level you recorded it at.

--

This change should be backwards compatible, because all of the other checks are still checking the `numChannels` so the only difference is how the `ScriptProcessorNode` deals with the input audio