### PR TITLE
Fix byte rate RIFF header value

### DIFF
--- a/recorderWorker.js
+++ b/recorderWorker.js
@@ -130,8 +130,8 @@ function encodeWAV(samples){
   view.setUint16(22, numChannels, true);
   /* sample rate */
   view.setUint32(24, sampleRate, true);
-  /* byte rate (sample rate * block align) */
-  view.setUint32(28, sampleRate * 4, true);
+  /* byte rate (sample rate * channels * bytes per sample) */
+  view.setUint32(28, sampleRate * numChannels * 2, true)
   /* block align (channel count * bytes per sample) */
   view.setUint16(32, numChannels * 2, true);
   /* bits per sample */


### PR DESCRIPTION
The byte rate calculation was hard-coded to 2 channels. Corrected this to include number of channels in the calculation.
