### PR TITLE
Added Mozilla vendor prefixed version for getUserMedia API in the example file.

### DIFF
--- a/examples/example_simple_exportwav.html
+++ b/examples/example_simple_exportwav.html
@@ -86,7 +86,7 @@
     try {
       // webkit shim
       window.AudioContext = window.AudioContext || window.webkitAudioContext;
-      navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia;
+      navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
       window.URL = window.URL || window.webkitURL;
       
       audio_context = new AudioContext;


### PR DESCRIPTION
Added vendor prefixed version `mozGetUserMedia` in the example file (example_simple_exportwav).
