### PR TITLE
Navigator.getUserMedia is deprecated

### DIFF
--- a/examples/example_simple_exportwav.html
+++ b/examples/example_simple_exportwav.html
@@ -86,7 +86,7 @@
     try {
       // webkit shim
       window.AudioContext = window.AudioContext || window.webkitAudioContext;
-      navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia;
+      navigator.getUserMedia = navigator.mediaDevices.getUserMedia || navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia;
       window.URL = window.URL || window.webkitURL;
       
       audio_context = new AudioContext;


### PR DESCRIPTION
[Use `navigator.mediaDevices.getUserMedia` instead](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getUserMedia).