### PR TITLE
Use revokeObjectURL to remove URLs

### DIFF
--- a/dist/recorder.js
+++ b/dist/recorder.js
@@ -289,6 +289,7 @@ var Recorder = exports.Recorder = (function () {
             var click = document.createEvent("Event");
             click.initEvent("click", true, true);
             link.dispatchEvent(click);
+            (window.URL || window.webkitURL).revokeObjectURL(url);
         }
     }]);
 

--- a/lib/recorder.js
+++ b/lib/recorder.js
@@ -269,6 +269,7 @@ var Recorder = exports.Recorder = function () {
             var click = document.createEvent("Event");
             click.initEvent("click", true, true);
             link.dispatchEvent(click);
+            (window.URL || window.webkitURL).revokeObjectURL(url);
         }
     }]);
 

--- a/src/recorder.js
+++ b/src/recorder.js
@@ -249,6 +249,7 @@ export class Recorder {
         let click = document.createEvent("Event");
         click.initEvent("click", true, true);
         link.dispatchEvent(click);
+        (window.URL || window.webkitURL).revokeObjectURL(url);
     }
 }
 


### PR DESCRIPTION
The URL is no longer needed as it gets downloaded the second the click event is dispatched.