### PR TITLE
Add possibility to resume recording

### DIFF
--- a/examples/example_simple_exportwav.html
+++ b/examples/example_simple_exportwav.html
@@ -18,7 +18,8 @@
 
   <button onclick="startRecording(this);">record</button>
   <button onclick="stopRecording(this);" disabled>stop</button>
-  
+  <button onclick="resumeRecording(this);" id='resume'>resume</button>
+
   <h2>Recordings</h2>
   <ul id="recordingslist"></ul>
   
@@ -64,6 +65,14 @@
     recorder.clear();
   }
 
+  function resumeRecording(button) {
+      recorder && recorder.stop();
+      audio_context.resume().then(() => {
+          __log('Playback resumed');
+      });
+
+      recorder.clear();
+  }
   function createDownloadLink() {
     recorder && recorder.exportWAV(function(blob) {
       var url = URL.createObjectURL(blob);


### PR DESCRIPTION
When clicking record I somehow always received a "The AudioContext was not allowed to start. It must be resumed (or created) after a user gesture on the page. https://goo.gl/7K7WLu" on the dev console, even after I restarted my PC. On my Win 10 64 bit Chrome 74.0.3729.157 that resulted in 0 Seconds, 44 bytes wav files. After adding the proposed resume button and clicking record after clicking resume it seems to work.